### PR TITLE
Dial the address on click

### DIFF
--- a/public/full.js
+++ b/public/full.js
@@ -927,6 +927,7 @@ async function fetchAddresses() {
 window.dialAddress = async (address) => {
   const destinationInput = document.getElementById('destination')
   destinationInput.value = address
+  connect()
 }
 
 window.fetchNextAddresses = async () => {


### PR DESCRIPTION
Clicking the dial button will now automatically populate the address field and initiate a direct call to the resource, eliminating the need for a manual click on the connect button.