### PR TITLE
Bug Fix: `Error: Invalid RTCPeer ID to hangup`

### DIFF
--- a/public/full.js
+++ b/public/full.js
@@ -531,7 +531,7 @@ window.hangup = () => {
     micAnalyzer.destroy()
   }
 
-  if (roomObj) {
+  if (roomObj && roomObj.state !== 'destroy') {
     roomObj.hangup()
   }
 


### PR DESCRIPTION
In a nested call scenario, the application gets `room.ended` events after the hangup.
this prevents the application from calling hangup again. 
