### PR TITLE
Remove unused checkboxes causing confusion

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -59,21 +59,6 @@
               <input type="text" class="form-control" id="destination" placeholder="<%= destination %>"
                 value="<%= destination %>" />
             </div>
-            <div class="form-group">
-              <div>Call Options:</div>
-              <div class="form-check">
-                <input type="checkbox" id="audio" value="1" checked />
-                <label class="form-check-label" for="audio">
-                  Include Audio
-                </label>
-              </div>
-              <div class="form-check">
-                <input type="checkbox" id="video" value="1" checked />
-                <label class="form-check-label" for="video">
-                  Include Video
-                </label>
-              </div>
-            </div>
             <div class="d-grid gap-2">
               <button id="btnConnect" class="btn btn-success" onclick="connect()">
                 Connect


### PR DESCRIPTION
They are holdovers from Video SDK and appear unused.

Channels can/will be used as they are more fully implemented.