### PR TITLE
Send push from the background message

### DIFF
--- a/public/full.js
+++ b/public/full.js
@@ -98,8 +98,9 @@ async function enablePushNotifications() {
   try {
     navigator.serviceWorker.addEventListener('message', event => {
       console.log(`The service worker sent me a message: ${event.data}`);
-      const body = JSON.parse(event.data.body || '{}')
-      handlePushNotification(body)
+      const message = JSON.parse(event.data || '{}')
+      // FIXME I think with a real payload the body needs to be parsed
+      handlePushNotification(message.notification.body)
       alert(body.title)
     });
 

--- a/public/full.js
+++ b/public/full.js
@@ -96,6 +96,13 @@ async function enablePushNotifications() {
   })
 
   try {
+    navigator.serviceWorker.addEventListener('message', event => {
+      console.log(`The service worker sent me a message: ${event.data}`);
+      const body = JSON.parse(event.data.body || '{}')
+      handlePushNotification(body)
+      alert(body.title)
+    });
+
     const registration = await navigator.serviceWorker.register(
       '/service-worker.js',
       {

--- a/public/full.js
+++ b/public/full.js
@@ -89,9 +89,9 @@ async function enablePushNotifications() {
   const messaging = FB.getMessaging(app)
 
   FB.onMessage(messaging, (payload) => {
-    console.log('Push payload', payload)
-    const body = JSON.parse(payload.notification.body || '{}')
-    handlePushNotification(body)
+    console.log('Push payload.data.message', payload.data.message)
+    const message = JSON.parse(payload.data.message);
+    handlePushNotification(message.notification.body)
     alert(body.title)
   })
 
@@ -99,7 +99,6 @@ async function enablePushNotifications() {
     navigator.serviceWorker.addEventListener('message', event => {
       console.log(`The service worker sent me a message: ${event.data}`);
       const message = JSON.parse(event.data || '{}')
-      // FIXME I think with a real payload the body needs to be parsed
       handlePushNotification(message.notification.body)
       alert(body.title)
     });

--- a/views/service-worker.ejs
+++ b/views/service-worker.ejs
@@ -24,7 +24,7 @@ try {
       message
     )
 
-    const payload = JSON.parse(message.data.default);
+    const payload = JSON.parse(message.data.message);
 
     // Customize notification here
     const notificationTitle = payload.notification.body?.title
@@ -37,7 +37,7 @@ try {
     self.clients.matchAll().then(function(clients) {
       clients.forEach(function(client) {
         console.log(client);
-        client.postMessage(JSON.stringify(payload));
+        client.postMessage(message.data.message);
       });
     });
 

--- a/views/service-worker.ejs
+++ b/views/service-worker.ejs
@@ -18,11 +18,14 @@ try {
   const firebaseApp = firebase.initializeApp(config)
 
   // Retrieve an instance of Firebase Messaging so that it can handle background messages.
-  firebase.messaging().onBackgroundMessage((payload) => {
+  firebase.messaging().onBackgroundMessage((message) => {
     console.log(
       '[service-worker.js] Received background message ',
-      payload
+      message
     )
+
+    const payload = JSON.parse(message.data.default);
+
     // Customize notification here
     const notificationTitle = payload.notification.body?.title
     const notificationOptions = {
@@ -34,7 +37,7 @@ try {
     self.clients.matchAll().then(function(clients) {
       clients.forEach(function(client) {
         console.log(client);
-        client.postMessage(payload.notification);
+        client.postMessage(JSON.stringify(payload));
       });
     });
 

--- a/views/service-worker.ejs
+++ b/views/service-worker.ejs
@@ -31,6 +31,13 @@ try {
 
     console.log('Notification', payload.notification)
 
+    self.clients.matchAll().then(function(clients) {
+      clients.forEach(function(client) {
+        console.log(client);
+        client.postMessage(payload.notification);
+      });
+    });
+
     self.registration.showNotification(notificationTitle, notificationOptions)
   })
 } catch (error) {


### PR DESCRIPTION
It's now listening to messages from the service worker on the page, and posting PN payloads from the service workers.

Before when the service worker was getting the PN, they got lost showing only in OS notifications.