### PR TITLE
Let env vars override callbackUrl host

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const fabricApiUrl = process.env.SIGNALWIRE_FABRIC_API_URL
 
 function getCallbackUrl(req) {
   const protocol = req.get('x-forwarded-proto') || req.protocol
-  return `${protocol}://${req.get('host')}/callback`
+  return process.env.OAUTH_REDIRECT_URI ?? `${protocol}://${req.get('host')}/callback`
 }
 
 async function apiRequest(uri, options) {


### PR DESCRIPTION
This is useful when using VSCODE dev tunnels 