### PR TITLE
Refresh auth token

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,11 +111,11 @@ async function getSubscriberToken(reference, password) {
   )
 }
 
-function updateSessionToken(req, tokenData) {
+function updateSessionToken(session, tokenData) {
   const tokenExpires = Math.floor(Date.now() / 1000 + (tokenData.expires_in || 0))
-  req.session.token = tokenData.access_token
-  req.session.refreshToken = tokenData.refresh_token
-  req.session.tokenExpires = tokenExpires
+  session.token = tokenData.access_token
+  session.refreshToken = tokenData.refresh_token
+  session.tokenExpires = tokenExpires
 }
 
 app.get('/', async (req, res) => {
@@ -127,7 +127,7 @@ app.get('/', async (req, res) => {
 
     if (Date.now() < req.session.tokenExpires * 1000) {
       const tokenData = await refreshAccessToken(req.session.refreshToken)
-      updateSessionToken(req, tokenData)
+      updateSessionToken(req.session, tokenData)
     }
   }
 
@@ -186,7 +186,7 @@ app.get('/callback', async (req, res) => {
 
   try {
     const tokenData = await getAccessToken(req.query.code, req.session.verifier, callbackUrl)
-    updateSessionToken(req, tokenData)
+    updateSessionToken(req.session, tokenData)
     const token = tokenData.access_token
 
     const userInfo = await getUserInfo(token)

--- a/index.js
+++ b/index.js
@@ -186,8 +186,8 @@ app.get('/callback', async (req, res) => {
 
   try {
     const tokenData = await getAccessToken(req.query.code, req.session.verifier, callbackUrl)
-    updateSessionToken(req.session, tokenData)
     const token = tokenData.access_token
+    updateSessionToken(req.session, tokenData)
 
     const userInfo = await getUserInfo(token)
     req.session.user = userInfo


### PR DESCRIPTION
Exploring refresh token use cases. In this case, we're only handling the case of reloading the tab/page after being away for a while. This would reset everything and give clean tokens in the connect and the rest api calls

Doesn't help if you're sitting in the page interacting with the app and expiration passes. For that, the js/sdk side can provide refresh.